### PR TITLE
fix: Fixed flaky tests.

### DIFF
--- a/src/Blazing.Mvvm.Tests/Infrastructure/Common/ServiceDescriptorComparer.cs
+++ b/src/Blazing.Mvvm.Tests/Infrastructure/Common/ServiceDescriptorComparer.cs
@@ -31,15 +31,26 @@ internal sealed class ServiceDescriptorComparer : IEqualityComparer<ServiceDescr
             return false;
         }
 
-        return x.IsKeyedService
-            ? x.ServiceType == y.ServiceType && x.KeyedImplementationType == y.KeyedImplementationType && x.Lifetime == y.Lifetime
-            : x.ServiceType == y.ServiceType && x.ImplementationType == y.ImplementationType && x.Lifetime == y.Lifetime && x.ServiceKey == y.ServiceKey;
+        if (x.IsKeyedService)
+        {
+            return CheckEquality(x.ServiceKey, y.ServiceKey)
+                && CheckEquality(x.ServiceType, y.ServiceType)
+                && CheckEquality(x.KeyedImplementationType, y.KeyedImplementationType)
+                && CheckEquality(x.Lifetime, y.Lifetime);
+        }
+
+        return CheckEquality(x.ServiceType, y.ServiceType)
+            && CheckEquality(x.ImplementationType, y.ImplementationType)
+            && CheckEquality(x.Lifetime, y.Lifetime);
+
+        static bool CheckEquality<T>(T first, T second)
+            => EqualityComparer<T>.Default.Equals(first, second);
     }
 
     public int GetHashCode(ServiceDescriptor serviceDescriptor)
     {
         return serviceDescriptor.IsKeyedService
-            ? HashCode.Combine(serviceDescriptor.ServiceType, serviceDescriptor.KeyedImplementationType, serviceDescriptor.Lifetime)
-            : HashCode.Combine(serviceDescriptor.ServiceType, serviceDescriptor.ImplementationType, serviceDescriptor.Lifetime, serviceDescriptor.ServiceKey);
+            ? HashCode.Combine(serviceDescriptor.ServiceKey, serviceDescriptor.ServiceType, serviceDescriptor.KeyedImplementationType, serviceDescriptor.Lifetime)
+            : HashCode.Combine(serviceDescriptor.ServiceType, serviceDescriptor.ImplementationType, serviceDescriptor.Lifetime);
     }
 }

--- a/src/Blazing.Mvvm.Tests/Infrastructure/Fakes/ViewModels.cs
+++ b/src/Blazing.Mvvm.Tests/Infrastructure/Fakes/ViewModels.cs
@@ -20,17 +20,17 @@ internal sealed class TransientTestViewModel : ViewModelBase, ITransientTestView
 internal sealed class ScopedTestViewModel : ViewModelBase, IScopedTestViewModel;
 
 [ViewModelDefinition<ISingletonTestViewModel>(Lifetime = ServiceLifetime.Singleton)]
-[ViewModelDefinition<ISingletonTestViewModel>(Key = "ISingleton", Lifetime = ServiceLifetime.Singleton)]
+[ViewModelDefinition<ISingletonTestViewModel>(Key = nameof(SingletonTestViewModel), Lifetime = ServiceLifetime.Singleton)]
 [ViewModelDefinition(Lifetime = ServiceLifetime.Singleton)]
 internal sealed class SingletonTestViewModel : ViewModelBase, ISingletonTestViewModel;
 
-[ViewModelDefinition(Key = "Transient", Lifetime = ServiceLifetime.Transient)]
+[ViewModelDefinition(Key = nameof(TransientKeyedTestViewModel), Lifetime = ServiceLifetime.Transient)]
 internal sealed class TransientKeyedTestViewModel : ViewModelBase;
 
-[ViewModelDefinition(Key = "Scoped", Lifetime = ServiceLifetime.Scoped)]
+[ViewModelDefinition(Key = nameof(ScopedKeyedTestViewModel), Lifetime = ServiceLifetime.Scoped)]
 internal sealed class ScopedKeyedTestViewModel : ViewModelBase;
 
-[ViewModelDefinition(Key = "Singleton", Lifetime = ServiceLifetime.Singleton)]
+[ViewModelDefinition(Key = nameof(SingletonKeyedTestViewModel), Lifetime = ServiceLifetime.Singleton)]
 internal sealed class SingletonKeyedTestViewModel : ViewModelBase;
 
 internal abstract class AbstractBaseViewModel : ViewModelBase;

--- a/src/Blazing.Mvvm.Tests/Infrastructure/Fakes/Views.cs
+++ b/src/Blazing.Mvvm.Tests/Infrastructure/Fakes/Views.cs
@@ -1,0 +1,14 @@
+﻿using Blazing.Mvvm.Components;
+using Microsoft.AspNetCore.Components;
+
+namespace Blazing.Mvvm.Tests.Infrastructure.Fakes;
+
+[ViewModelKey(nameof(SingletonTestViewModel))]
+[Route("/singleton")]
+internal class SingletonTestView : MvvmComponentBase<ISingletonTestViewModel>
+{ }
+
+[ViewModelKey(nameof(SingletonKeyedTestViewModel))]
+[Route("/singleton-keyed")]
+internal class SingletonKeyedTestView : MvvmComponentBase<SingletonKeyedTestViewModel>
+{ }

--- a/src/Blazing.Mvvm.Tests/UnitTests/MvvmNavigationManagerTests.cs
+++ b/src/Blazing.Mvvm.Tests/UnitTests/MvvmNavigationManagerTests.cs
@@ -117,8 +117,10 @@ public class MvvmNavigationManagerTests
             .WithMessage("No associated page for key 'InvalidKey'");
     }
 
-    [Fact]
-    public void GetUri_GivenValidKey_ShouldReturnUri()
+    [Theory]
+    [InlineData(nameof(SingletonTestViewModel), "/singleton")]
+    [InlineData(nameof(SingletonKeyedTestViewModel), "/singleton-keyed")]
+    public void GetUri_GivenValidKey_ShouldReturnUri(string key, string expectedRoute)
     {
         // Arrange
         Mock<NavigationManager> navigationManagerMock = new();
@@ -126,9 +128,9 @@ public class MvvmNavigationManagerTests
         MvvmNavigationManager mvvmNavigationManager = new(navigationManagerMock.Object, loggerMock.Object);
 
         // Act
-        string uri = mvvmNavigationManager.GetUri(nameof(TestKeyedNavigationViewModel));
+        string uri = mvvmNavigationManager.GetUri(key);
 
         // Assert
-        uri.Should().Be("/keyedtest");
+        uri.Should().Be(expectedRoute);
     }
 }

--- a/src/Blazing.Mvvm.Tests/UnitTests/ServicesExtensionTests.cs
+++ b/src/Blazing.Mvvm.Tests/UnitTests/ServicesExtensionTests.cs
@@ -136,16 +136,16 @@ public class ServicesExtensionTests
             { ServiceDescriptor.Transient<TransientTestViewModel, TransientTestViewModel>() },
             { ServiceDescriptor.Transient<ITransientTestViewModel, TransientTestViewModel>() },
             { ServiceDescriptor.Transient<AbstractBaseViewModel, ConcreteViewModel>() },
-            { ServiceDescriptor.KeyedTransient<TransientKeyedTestViewModel, TransientKeyedTestViewModel>("Transient") },
+            { ServiceDescriptor.KeyedTransient<TransientKeyedTestViewModel, TransientKeyedTestViewModel>(nameof(TransientKeyedTestViewModel)) },
 
             { ServiceDescriptor.Scoped<ScopedTestViewModel, ScopedTestViewModel>() },
             { ServiceDescriptor.Scoped<IScopedTestViewModel, ScopedTestViewModel>() },
-            { ServiceDescriptor.KeyedScoped<ScopedKeyedTestViewModel, ScopedKeyedTestViewModel>("Scoped") },
+            { ServiceDescriptor.KeyedScoped<ScopedKeyedTestViewModel, ScopedKeyedTestViewModel>(nameof(ScopedKeyedTestViewModel)) },
 
             { ServiceDescriptor.Singleton<SingletonTestViewModel, SingletonTestViewModel>() },
             { ServiceDescriptor.Singleton<ISingletonTestViewModel, SingletonTestViewModel>() },
-            { ServiceDescriptor.KeyedSingleton<ISingletonTestViewModel, SingletonTestViewModel>("ISingleton") },
-            { ServiceDescriptor.KeyedSingleton<SingletonKeyedTestViewModel, SingletonKeyedTestViewModel>("Singleton") }
+            { ServiceDescriptor.KeyedSingleton<ISingletonTestViewModel, SingletonTestViewModel>(nameof(SingletonTestViewModel)) },
+            { ServiceDescriptor.KeyedSingleton<SingletonKeyedTestViewModel, SingletonKeyedTestViewModel>(nameof(SingletonKeyedTestViewModel)) }
         };
 
         public static TheoryData<ServiceDescriptor> ViewModelsInDependentAssembly = new()


### PR DESCRIPTION
- Refactored `ServiceDescriptorComparer` for readability and maintainability by encapsulating equality check logic in a new `CheckEquality` method and adjusting `GetHashCode` to include `ServiceKey`.
- Updated `ViewModelDefinition` attributes in `ViewModels.cs` and `ServicesExtensionTests` to use `nameof` expressions, enhancing refactorability and reducing typo risks.
-  Enhanced `MvvmNavigationManagerTests` with `[Theory]` and `[InlineData]` for better test coverage. Added new view classes `SingletonTestView` and `SingletonKeyedTestView` in `Views.cs`, linking them to view models and routes.