### PR TITLE
IsActive = false

### DIFF
--- a/src/Blazing.Mvvm/Components/MvvmComponentBase.cs
+++ b/src/Blazing.Mvvm/Components/MvvmComponentBase.cs
@@ -96,6 +96,11 @@ public abstract class MvvmComponentBase<TViewModel> : ComponentBase, IView<TView
         if (disposing)
         {
             ViewModel.PropertyChanged -= OnPropertyChanged;
+            ObservableRecipient? observableRecipient  = (base.ViewModel as ObservableRecipient);
+            if(observableRecipient != null)
+            {
+                observableRecipient.IsActive = false;
+            }
         }
 
         IsDisposed = true;


### PR DESCRIPTION
Fix for ticket #13
IsActive = false when Page/Blazor object is close
No new posts on the VM when underlighted page is closed.
Otherwise you will get the message N times as many times as you ever opened it.