### PR TITLE
feat: net10.0 support; multi-target frameworks for tests and samples

### DIFF
--- a/docs/Running_Different_NET_Versions.md
+++ b/docs/Running_Different_NET_Versions.md
@@ -1,0 +1,509 @@
+# Running Sample Projects with Different .NET Target Frameworks
+
+This document explains how to run the sample projects targeting different versions of .NET (8.0, 9.0, and 10.0).
+
+## Table of Contents
+
+1. [Available Target Frameworks](#available-target-frameworks)
+2. [How to Select Framework Versions](#how-to-select-framework-versions)
+   - [Method 1: Using Visual Studio (Recommended)](#method-1-using-visual-studio-recommended)
+   - [Method 2: Using .NET CLI](#method-2-using-net-cli-alternative-method)
+3. [Running Different Project Types](#running-different-project-types)
+   - [Blazor Web Applications](#blazor-web-applications)
+   - [Desktop Hybrid Applications](#desktop-hybrid-applications)
+   - [MAUI Cross-Platform Applications](#maui-cross-platform-applications)
+4. [Understanding Multi-Targeted Projects](#understanding-multi-targeted-projects)
+5. [Visual Studio UI Guide](#visual-studio-ui-guide)
+6. [Prerequisites](#prerequisites)
+7. [Common Issues and Solutions](#common-issues-and-solutions)
+8. [Package Versioning](#package-versioning)
+9. [Testing and Validation](#testing-and-validation)
+
+## Available Target Frameworks
+
+The sample projects in this solution support multi-targeting across the following frameworks:
+
+### Core Library Projects
+- **Blazing.Mvvm**: `net8.0`, `net9.0`, `net10.0`
+- **Blazing.Mvvm.Base**: `net8.0`, `net9.0`, `net10.0`
+
+### Blazor Web Sample Projects
+- **Blazing.Mvvm.Sample.Wasm** (WebAssembly): `net8.0`, `net9.0`, `net10.0`
+- **Blazing.Mvvm.Sample.Server** (Server-side): `net8.0`, `net9.0`, `net10.0`  
+- **Blazing.Mvvm.Sample.WebApp** (Blazor Web App): `net8.0`, `net9.0`, `net10.0`
+- **Blazing.SubpathHosting.Server** (Subpath Hosting): `net8.0`, `net9.0`, `net10.0`
+
+### Desktop Hybrid Sample Projects
+- **HybridSample.Wpf** (WPF + Blazor): `net8.0-windows`, `net9.0-windows`, `net10.0-windows`
+- **HybridSample.Avalonia** (Avalonia + Blazor): `net8.0-windows`, `net9.0-windows`, `net10.0-windows`
+
+#### Supporting Libraries for Desktop Hybrid
+- **HybridSample.Core**: `net8.0`, `net9.0`, `net10.0`
+- **HybridSample.Blazor.Core**: `net8.0`, `net9.0`, `net10.0`
+- **Blazing.Common**: `net8.0`, `net9.0`, `net10.0`
+- **Blazing.Lists**: `net8.0`, `net9.0`, `net10.0`
+- **Blazing.Tabs**: `net8.0`, `net9.0`, `net10.0`
+- **Baksteen.Avalonia.Blazor**: `net8.0-windows`, `net9.0-windows`, `net10.0-windows`
+
+### MAUI Cross-Platform Sample Projects
+- **Blazing.Mvvm.Sample.HybridMaui**: Multiple targets including:
+  - **.NET 9.0**: `net9.0-android`, `net9.0-ios`, `net9.0-maccatalyst`, `net9.0-windows10.0.19041.0`
+  - **.NET 10.0**: `net10.0-android`, `net10.0-ios`, `net10.0-maccatalyst`, `net10.0-windows10.0.19041.0`
+
+## How to Select Framework Versions
+
+### Method 1: Using Visual Studio
+
+#### **Start With Debugging Dropdown Button**
+
+**ALL projects in this solution are multi-targeted** and build for multiple frameworks simultaneously. To **select which specific framework to run**:
+
+1. **Right-click on the project** you want to run in Solution Explorer
+2. **Select "Set as Startup Project"**
+3. **Look for the Start With Debugging Dropdown Run Button** (green solid) in the **Visual Studio toolbar**:
+   - **Location**: Next to the Start Without Debugging Run (green hollow) button
+4. **Select your desired target framework/platform from the dropdown**
+5. **Press F5 or click the Run button**
+
+#### **Editing Target Framework Lists**
+
+To **modify which frameworks a project builds for**:
+
+1. **Right-click on the project** -> **Properties** -> **Application** tab
+2. **Look for "Target frameworks" field** (plural) - you can edit the semicolon-separated list here
+3. **Or manually edit the .csproj file** and modify the `<TargetFrameworks>` property
+4. **Reload the project** after making changes
+
+### Method 2: Using .NET CLI (Alternative Method)
+
+You can specify the exact target framework when building or running projects using the `-f` or `--framework` parameter:
+
+```bash
+# Build for specific framework
+dotnet build -f <target-framework>
+
+# Run for specific framework  
+dotnet run -f <target-framework>
+```
+
+**Common Framework Identifiers:**
+- **Standard .NET**: `net8.0`, `net9.0`, `net10.0`
+- **Windows-specific**: `net8.0-windows`, `net9.0-windows`, `net10.0-windows`
+- **Android**: `net9.0-android`, `net10.0-android`
+- **iOS**: `net9.0-ios`, `net10.0-ios`
+- **macOS**: `net9.0-maccatalyst`, `net10.0-maccatalyst`
+- **Windows (MAUI)**: `net9.0-windows10.0.19041.0`, `net10.0-windows10.0.19041.0`
+
+## Running Different Project Types
+
+### Blazor Web Applications
+
+Blazor web applications are the easiest to run and test across different .NET versions.
+
+#### **WebAssembly (Client-side Blazor)**
+
+**Project**: `Blazing.Mvvm.Sample.Wasm`  
+**Target Frameworks**: `net8.0`, `net9.0`, `net10.0`
+
+##### Visual Studio:
+1. Set `Blazing.Mvvm.Sample.Wasm` as startup project
+2. Select framework from Run with Debugging toolbar dropdown button: `net8.0`, `net9.0`, or `net10.0`
+3. Press F5 to run
+
+##### CLI:
+```bash
+cd samples/Blazing.Mvvm.Sample.Wasm
+
+# Run .NET 8.0
+dotnet run -f net8.0
+
+# Run .NET 9.0
+dotnet run -f net9.0
+
+# Run .NET 10.0  
+dotnet run -f net10.0
+```
+
+#### **Server-side Blazor**
+
+**Project**: `Blazing.Mvvm.Sample.Server`  
+**Target Frameworks**: `net8.0`, `net9.0`, `net10.0`
+
+##### Visual Studio:
+1. Set `Blazing.Mvvm.Sample.Server` as startup project
+2. Select framework from Run with Debugging toolbar dropdown button: `net8.0`, `net9.0`, or `net10.0`
+3. Press F5 to run
+
+##### CLI:
+```bash
+cd samples/Blazing.Mvvm.Sample.Server
+
+# Run .NET 8.0
+dotnet run -f net8.0
+
+# Run .NET 9.0
+dotnet run -f net9.0
+
+# Run .NET 10.0
+dotnet run -f net10.0
+```
+
+#### **Blazor Web App (.NET 8+)**
+
+**Project**: `Blazing.Mvvm.Sample.WebApp`  
+**Target Frameworks**: `net8.0`, `net9.0`, `net10.0`
+
+##### Visual Studio:
+1. Set `Blazing.Mvvm.Sample.WebApp` as startup project
+2. Select framework from Run with Debugging toolbar dropdown button: `net8.0`, `net9.0`, or `net10.0`
+3. Press F5 to run
+
+##### CLI:
+```bash
+cd samples/Blazing.Mvvm.Sample.WebApp/Blazing.Mvvm.Sample.WebApp
+
+# Run .NET 8.0
+dotnet run -f net8.0
+
+# Run .NET 9.0
+dotnet run -f net9.0
+
+# Run .NET 10.0
+dotnet run -f net10.0
+```
+
+#### **Subpath Hosting Server**
+
+**Project**: `Blazing.SubpathHosting.Server`  
+**Target Frameworks**: `net8.0`, `net9.0`, `net10.0`
+
+##### Visual Studio:
+1. Set `Blazing.SubpathHosting.Server` as startup project
+2. Select framework from Run with Debugging toolbar dropdown button: `net8.0`, `net9.0`, or `net10.0`
+3. Press F5 to run
+
+##### CLI:
+```bash
+cd samples/Blazing.SubpathHosting.Server
+
+# Run .NET 8.0
+dotnet run -f net8.0
+
+# Run .NET 9.0
+dotnet run -f net9.0
+
+# Run .NET 10.0
+dotnet run -f net10.0
+```
+
+### Desktop Hybrid Applications
+
+Desktop hybrid applications combine native desktop UI frameworks (WPF/Avalonia) with Blazor components using WebView.
+
+#### **WPF + Blazor Hybrid**
+
+**Project**: `HybridSample.Wpf`  
+**Target Frameworks**: `net8.0-windows`, `net9.0-windows`, `net10.0-windows`
+
+##### Visual Studio:
+1. Set `HybridSample.Wpf` as startup project  
+2. Select framework from Run with Debugging toolbar dropdown button: `net8.0-windows`, `net9.0-windows`, or `net10.0-windows`
+3. Press F5 to run
+
+##### CLI:
+```bash
+cd samples/HybridSamples/HybridSample.Wpf
+
+# Run .NET 8.0 on Windows
+dotnet run -f net8.0-windows
+
+# Run .NET 9.0 on Windows
+dotnet run -f net9.0-windows
+
+# Run .NET 10.0 on Windows
+dotnet run -f net10.0-windows
+```
+
+#### **Avalonia + Blazor Hybrid**
+
+**Project**: `HybridSample.Avalonia`  
+**Target Frameworks**: `net8.0-windows`, `net9.0-windows`, `net10.0-windows`
+
+##### Visual Studio:
+1. Set `HybridSample.Avalonia` as startup project
+2. Select framework from Run with Debugging toolbar dropdown button: `net8.0-windows`, `net9.0-windows`, or `net10.0-windows`  
+3. Press F5 to run
+
+##### CLI:
+```bash
+cd samples/HybridSamples/HybridSample.Avalonia
+
+# Run .NET 8.0 on Windows
+dotnet run -f net8.0-windows
+
+# Run .NET 9.0 on Windows
+dotnet run -f net9.0-windows
+
+# Run .NET 10.0 on Windows  
+dotnet run -f net10.0-windows
+```
+
+### MAUI Cross-Platform Applications
+
+MAUI applications are the most complex as they target multiple platforms simultaneously.
+
+#### **MAUI Blazor Hybrid**
+
+**Project**: `Blazing.Mvvm.Sample.HybridMaui`  
+**Target Frameworks**: 
+- **.NET 9.0**: `net9.0-android`, `net9.0-ios`, `net9.0-maccatalyst`, `net9.0-windows10.0.19041.0`
+- **.NET 10.0**: `net10.0-android`, `net10.0-ios`, `net10.0-maccatalyst`, `net10.0-windows10.0.19041.0`
+
+##### Visual Studio:
+1. Set `Blazing.Mvvm.Sample.HybridMaui` as startup project
+2. Select platform and framework from toolbar dropdown:
+   - **Android**: `net9.0-android`, `net10.0-android`
+   - **iOS**: `net9.0-ios`, `net10.0-ios` (macOS only)
+   - **macOS**: `net9.0-maccatalyst`, `net10.0-maccatalyst` (macOS only)
+   - **Windows**: `net9.0-windows10.0.19041.0`, `net10.0-windows10.0.19041.0`
+3. Press F5 to run (will deploy to selected platform)
+
+##### CLI:
+
+**Android:**
+```bash
+cd samples/Blazing.Mvvm.Sample.HybridMaui
+
+# Build for .NET 9.0 Android
+dotnet build -f net9.0-android
+
+# Build for .NET 10.0 Android
+dotnet build -f net10.0-android
+```
+
+**iOS (macOS only):**
+```bash
+cd samples/Blazing.Mvvm.Sample.HybridMaui
+
+# Build for .NET 9.0 iOS
+dotnet build -f net9.0-ios
+
+# Build for .NET 10.0 iOS
+dotnet build -f net10.0-ios
+```
+
+**macOS Catalyst (macOS only):**
+```bash
+cd samples/Blazing.Mvvm.Sample.HybridMaui
+
+# Build for .NET 9.0 macOS
+dotnet build -f net9.0-maccatalyst
+
+# Build for .NET 10.0 macOS
+dotnet build -f net10.0-maccatalyst
+```
+
+**Windows:**
+```bash
+cd samples/Blazing.Mvvm.Sample.HybridMaui
+
+# Run .NET 9.0 Windows
+dotnet run -f net9.0-windows10.0.19041.0
+
+# Run .NET 10.0 Windows
+dotnet run -f net10.0-windows10.0.19041.0
+```
+
+## Understanding Multi-Targeted Projects
+
+### **All Projects in This Solution are Multi-Targeted**
+- **Project File Property**: Uses `<TargetFrameworks>` (plural)
+- **Behavior**: Build for ALL target frameworks simultaneously
+- **Visual Studio Running**: Use Start With Debugging Dropdown Button in toolbar
+- **Visual Studio Editing**: Properties -> Application -> "Target frameworks" (plural) to modify the list
+- **Examples**:
+  - **Blazor**: `<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>`
+  - **WPF/Avalonia**: `<TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>`
+  - **MAUI**: `<TargetFrameworks>net9.0-android;net9.0-ios;net10.0-android;net10.0-ios</TargetFrameworks>`
+  - **Core Libraries**: `<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>`
+
+## Visual Studio UI Guide
+
+### **Start With Debugging Dropdown Button (Toolbar)**
+- **Location**: Visual Studio toolbar, next to Start Without Debugging Run button button
+- **Purpose**: **Select which framework to RUN** from multi-targeted projects
+- **Appears when**: Multi-targeted project is set as startup project
+- **Examples**:
+  - **Blazor**: `net8.0`, `net9.0`, `net10.0`
+  - **WPF/Avalonia**: `net8.0-windows`, `net9.0-windows`, `net10.0-windows`
+  - **MAUI**: `net9.0-android`, `net9.0-windows10.0.19041.0`, `net10.0-android`, `net10.0-windows10.0.19041.0`
+
+### **"Target frameworks" (Properties)**
+- **Location**: Project Properties -> Application tab  
+- **Purpose**: **Edit the semicolon-separated list of target frameworks** the project builds for
+- **Shows**: Editable text field with frameworks like `net8.0;net9.0;net10.0`
+- **Note**: Shows "Target frameworks" (plural) for all projects in this solution
+
+### **Quick Start Guide**
+
+#### **To Run a Specific Framework Version:**
+1. **Set project as startup project** (right-click -> "Set as Startup Project")
+2. **Find the Start Without Debugging Run button** in Visual Studio toolbar
+3. **Select your desired framework** (e.g., `net8.0`, `net9.0`, `net10.0-android`)
+4. **Press F5 or click Run**
+
+#### **To Change Which Frameworks a Project Targets:**
+1. **Right-click project** -> **Properties** -> **Application**
+2. **Edit "Target frameworks" field** (semicolon-separated list)
+3. **Reload project** when prompted
+
+## Prerequisites
+
+### For .NET 8.0 Projects:
+- **.NET 8 SDK** installed
+- **Visual Studio 2022 17.8+** or **Visual Studio Code** with C# extension
+
+### For .NET 9.0 Projects:
+- **.NET 9 SDK** installed  
+- **Visual Studio 2022 17.12+** or **Visual Studio Code** with C# extension
+
+### For .NET 10.0 Projects:
+- **.NET 10 SDK** installed
+- **Visual Studio 2022 17.13+** or **Visual Studio Code** with C# extension
+
+### For Windows-specific projects (WPF, Avalonia):
+- **Windows 10 version 1809 or later**
+- **Windows SDK** installed
+
+### For MAUI projects:
+- **MAUI workload** installed:
+  ```bash
+  dotnet workload install maui
+  ```
+- **Platform-specific requirements**:
+  - **Android**: Android SDK 24.0+
+  - **iOS**: Xcode (macOS only) 
+  - **macOS**: Xcode (macOS only)
+  - **Windows**: Windows 10 version 19041.0+
+
+### Checking Your .NET Installation
+
+To verify which .NET versions you have installed:
+
+```bash
+# List all installed .NET versions
+dotnet --list-sdks
+
+# Check current .NET version
+dotnet --version
+
+# List installed workloads
+dotnet workload list
+```
+
+## Common Issues and Solutions
+
+### Issue: "Can't see Start With Debugging Dropdown Button in toolbar"
+**Solution**: 
+- **Confirm the project is multi-targeted** (all projects in this solution are)
+- **Set the project as startup project** (right-click -> "Set as Startup Project")
+- **Look next to the Run without Debugging dropdown Button**
+
+### Issue: "Can't see Target framework dropdown in Properties"
+**Solution**: All projects in this solution are multi-targeted, so you'll see "Target frameworks" (plural) as an editable text field instead of a dropdown. You can edit the semicolon-separated list directly.
+
+### Issue: "The specified framework is not available"
+**Solution**: Install the required .NET SDK version:
+```bash
+# Download from: https://dotnet.microsoft.com/download
+```
+
+### Issue: Build errors with WebView components (Desktop Hybrid)
+**Solution**: Ensure you have the correct Windows SDK and WebView2 runtime installed:
+- Install Visual Studio with "Windows application development" workload
+- WebView2 runtime is usually installed automatically with Windows 11 or can be downloaded from Microsoft
+
+### Issue: MAUI project won't run
+**Solution**: Install MAUI workload and ensure correct platform SDKs:
+```bash
+dotnet workload install maui
+dotnet workload restore
+```
+
+### Issue: Android build fails (MAUI)
+**Solution**: Ensure Android SDK is properly configured:
+```bash
+# Check Android SDK path in Visual Studio or set ANDROID_HOME environment variable
+# Install Android SDK 24.0 or higher
+```
+
+### Issue: iOS/macOS build fails (MAUI - macOS only)
+**Solution**: Ensure Xcode is installed and up to date:
+```bash
+# Install Xcode from Mac App Store
+# Accept Xcode license: sudo xcodebuild -license accept
+```
+
+## Package Versioning
+
+The project uses Central Package Management with conditional versioning:
+- **For .NET 8.0**: Uses v8.x packages  
+- **For .NET 9.0**: Uses v9.x packages
+- **For .NET 10.0**: Uses v10.x packages
+
+This is configured in the `Directory.Packages.props` file at the solution root.
+
+### MAUI-Specific Packages:
+- **Microsoft.Maui.Controls**: Automatically versioned based on target framework
+- **Microsoft.AspNetCore.Components.WebView.Maui**: Matches .NET version
+- **Microsoft.Extensions.Logging.Debug**: Matches .NET version
+
+### Blazor-Specific Packages:
+- **Microsoft.AspNetCore.Components.WebAssembly**: Framework-specific versions
+- **Microsoft.AspNetCore.Components.Web**: Framework-specific versions
+
+### Desktop Hybrid-Specific Packages:
+- **Microsoft.AspNetCore.Components.WebView.Wpf**: Framework-specific versions for WPF
+- **Custom Avalonia WebView**: Uses Baksteen.Avalonia.Blazor library for Avalonia integration
+
+## Testing and Validation
+
+### Testing Multi-Target Builds
+
+To ensure all target frameworks build correctly:
+
+```bash
+# Build entire solution for all target frameworks
+dotnet build
+
+# Build specific project for all its target frameworks
+dotnet build samples/HybridSamples/HybridSample.Wpf
+
+# Build MAUI project for all platforms
+dotnet build samples/Blazing.Mvvm.Sample.HybridMaui
+
+# Restore packages for all frameworks
+dotnet restore
+```
+
+### Running MAUI Apps on Different Platforms
+
+#### Android Emulator:
+```bash
+# Build and deploy to Android
+dotnet build samples/Blazing.Mvvm.Sample.HybridMaui -f net9.0-android
+# Deploy to emulator or device via Visual Studio
+```
+
+#### Windows:
+```bash
+# Run on Windows
+dotnet run --project samples/Blazing.Mvvm.Sample.HybridMaui -f net9.0-windows10.0.19041.0
+```
+
+#### iOS Simulator (macOS only):
+```bash
+# Build for iOS
+dotnet build samples/Blazing.Mvvm.Sample.HybridMaui -f net9.0-ios
+# Deploy via Visual Studio for Mac or Xcode
+```

--- a/src/Blazing.Mvvm.Base/Blazing.Mvvm.Base.csproj
+++ b/src/Blazing.Mvvm.Base/Blazing.Mvvm.Base.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageId>Blazing.Mvvm.Base</PackageId>

--- a/src/Blazing.Mvvm.Tests/Blazing.Mvvm.Tests.csproj
+++ b/src/Blazing.Mvvm.Tests/Blazing.Mvvm.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Blazing.Mvvm.Tests/Infrastructure/Common/ComponentTestBase.cs
+++ b/src/Blazing.Mvvm.Tests/Infrastructure/Common/ComponentTestBase.cs
@@ -12,6 +12,23 @@ public abstract class ComponentTestBase : TestContext
     {
         _autoMocker = AutoMockerFactory();
         Services.AddFallbackServiceProvider(new MockServiceProvider(_autoMocker));
+        
+#if NET10_0
+        // For .NET 10.0, manually register ComponentsMetrics service as singleton
+        // This is required by the Blazor renderer in .NET 10.0
+        try
+        {
+            var componentsMetricsType = Type.GetType("Microsoft.AspNetCore.Components.ComponentsMetrics, Microsoft.AspNetCore.Components");
+            if (componentsMetricsType != null)
+            {
+                Services.AddSingleton(componentsMetricsType, _ => null!);
+            }
+        }
+        catch
+        {
+            // Ignore if the type doesn't exist or can't be loaded
+        }
+#endif
     }
 
     protected virtual AutoMocker AutoMockerFactory()

--- a/src/Blazing.Mvvm.Tests/Infrastructure/Common/MockServiceProvider.cs
+++ b/src/Blazing.Mvvm.Tests/Infrastructure/Common/MockServiceProvider.cs
@@ -17,6 +17,14 @@ public class MockServiceProvider : IServiceProvider
             return null;
         }
 
+#if NET10_0
+        // Handle ComponentsMetrics service for .NET 10.0
+        if (serviceType.Name == "ComponentsMetrics")
+        {
+            return null; // Return null to indicate it's not available
+        }
+#endif
+
         // Create real instances of ViewModels and not mock them.
         if (!serviceType.IsAbstract && serviceType.IsAssignableTo(typeof(IViewModelBase)) && !_autoMocker.ResolvedObjects.ContainsKey(serviceType))
         {

--- a/src/Blazing.Mvvm.sln
+++ b/src/Blazing.Mvvm.sln
@@ -64,6 +64,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazing.Mvvm.Sample.WebApp"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazing.Mvvm.Sample.WebApp.Client", "samples\Blazing.Mvvm.Sample.WebApp\Blazing.Mvvm.Sample.WebApp.Client\Blazing.Mvvm.Sample.WebApp.Client.csproj", "{082E5E74-ED2C-20FE-125F-63331CD86437}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Migration Notes", "Migration Notes", "{17E67D4F-836D-4485-9486-9084304BB356}"
+	ProjectSection(SolutionItems) = preProject
+		..\docs\migration-notes\v1.4_to_v2.md = ..\docs\migration-notes\v1.4_to_v2.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Framework Version", "Framework Version", "{66958A82-6DE9-4085-8132-9EEDB53D9F2D}"
+	ProjectSection(SolutionItems) = preProject
+		..\docs\Running_Different_NET_Versions.md = ..\docs\Running_Different_NET_Versions.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -164,6 +174,8 @@ Global
 		{0B1263FC-A679-6F4C-D715-EDEE81C00614} = {F517F8B5-53D1-43DB-B0FE-A603C8BD343F}
 		{2C4EED6F-1E39-9B0A-9990-51AF9EFCFD7E} = {8BEC7F26-63FA-4B22-9B55-53D138AFF17D}
 		{082E5E74-ED2C-20FE-125F-63331CD86437} = {8BEC7F26-63FA-4B22-9B55-53D138AFF17D}
+		{17E67D4F-836D-4485-9486-9084304BB356} = {225ACB45-5BBE-48D0-A1FB-802E767F6D21}
+		{66958A82-6DE9-4085-8132-9EEDB53D9F2D} = {225ACB45-5BBE-48D0-A1FB-802E767F6D21}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2D6F818A-4305-467B-BB8E-E1AB2BEAC979}

--- a/src/Blazing.Mvvm/Blazing.Mvvm.csproj
+++ b/src/Blazing.Mvvm/Blazing.Mvvm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageId>Blazing.Mvvm</PackageId>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,27 +3,52 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- See Maui Issue: https://github.com/dotnet/sdk/issues/27840 -->
     <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
-    <!-- MAUI Version for .NET 9.0 -->
-    <MauiVersion>9.0.10</MauiVersion>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Common packages -->
+    <!-- Common packages - use latest compatible versions -->
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <!-- .NET 8.0 specific packages -->
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    
+    <!-- ASP.NET Core packages with conditions -->
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     
-    <!-- MAUI packages for .NET 9.0 -->
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
+    <!-- MAUI packages with proper conditions for multi-platform support -->
+    <!-- .NET 8.0 MAUI packages -->
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.90" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="8.0.90" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.10" Condition="'$(TargetFramework)' == 'net8.0'" />
     
-    <!-- Samples -->
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.10" PrivateAssets="all" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.10" />
+    <!-- .NET 9.0 MAUI packages -->
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.10" Condition="$(TargetFramework.StartsWith('net9.0'))" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.10" Condition="$(TargetFramework.StartsWith('net9.0'))" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" Condition="$(TargetFramework.StartsWith('net9.0'))" />
+    
+    <!-- .NET 10.0 MAUI packages -->
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.0" Condition="$(TargetFramework.StartsWith('net10.0'))" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.0" Condition="$(TargetFramework.StartsWith('net10.0'))" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" Condition="$(TargetFramework.StartsWith('net10.0'))" />
+    
+    <!-- WebAssembly packages with conditions -->
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.10" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
+    
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
+    
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.10" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net10.0'" />
+    
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.10" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
+    
     <!-- Tests -->
     <PackageVersion Include="bunit.web.query" Version="1.28.4-preview" />
     <PackageVersion Include="bunit" Version="1.34.0" />
@@ -39,20 +64,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <!-- .NET 9.0 specific packages -->
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <!-- Update to .NET 9.0 version when targeting .NET 9.0 -->
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageVersion Update="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <!-- Samples -->
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-    <!-- HybridSamples packages -->
+    
+    <!-- HybridSamples packages - use latest compatible versions -->
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="1.0.2" />
     <PackageVersion Include="Refit" Version="7.2.22" />
     <PackageVersion Include="Markdig" Version="0.37.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    
     <!-- Avalonia packages -->
     <PackageVersion Include="Avalonia" Version="11.2.0" />
     <PackageVersion Include="Avalonia.Desktop" Version="11.2.0" />
@@ -61,8 +81,19 @@
     <PackageVersion Include="Avalonia.ReactiveUI" Version="11.2.0" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.0" />
     <PackageVersion Include="Avalonia.Themes.Simple" Version="11.2.0" />
-    <!-- WebView packages -->
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="8.0.10" />
+    
+    <!-- WebView packages for different target frameworks -->
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="8.0.10" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0-windows'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0-windows'" />
+    
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="8.0.10" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0-windows'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0-windows'" />
+
+    <!-- WebView base package for RootComponentsCollection support -->
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView" Version="8.0.10" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0-windows'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0-windows'" />
   </ItemGroup>
 </Project>

--- a/src/samples/Blazing.Mvvm.Sample.HybridMaui/Blazing.Mvvm.Sample.HybridMaui.csproj
+++ b/src/samples/Blazing.Mvvm.Sample.HybridMaui/Blazing.Mvvm.Sample.HybridMaui.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-    <!-- See Maui Issue: https://github.com/dotnet/sdk/issues/27840 -->
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <!-- Enable Central Package Management to leverage conditional versioning -->
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
-		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen;net10.0-tizen</TargetFrameworks> -->
 
 		<!-- Note for MacCatalyst:
             The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
@@ -62,9 +62,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+		<!-- Package references now handled by Central Package Management -->
+		<PackageReference Include="Microsoft.Maui.Controls" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/samples/Blazing.Mvvm.Sample.Server/Blazing.Mvvm.Sample.Server.csproj
+++ b/src/samples/Blazing.Mvvm.Sample.Server/Blazing.Mvvm.Sample.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
+	  <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/samples/Blazing.Mvvm.Sample.Wasm/Blazing.Mvvm.Sample.Wasm.csproj
+++ b/src/samples/Blazing.Mvvm.Sample.Wasm/Blazing.Mvvm.Sample.Wasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
+	  <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/samples/Blazing.Mvvm.Sample.WebApp/Blazing.Mvvm.Sample.WebApp.Client/Blazing.Mvvm.Sample.WebApp.Client.csproj
+++ b/src/samples/Blazing.Mvvm.Sample.WebApp/Blazing.Mvvm.Sample.WebApp.Client/Blazing.Mvvm.Sample.WebApp.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
+	  <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 	  <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
     <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
   </PropertyGroup>

--- a/src/samples/Blazing.Mvvm.Sample.WebApp/Blazing.Mvvm.Sample.WebApp/Blazing.Mvvm.Sample.WebApp.csproj
+++ b/src/samples/Blazing.Mvvm.Sample.WebApp/Blazing.Mvvm.Sample.WebApp/Blazing.Mvvm.Sample.WebApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
+	  <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/samples/Blazing.SubpathHosting.Server/Blazing.SubpathHosting.Server.csproj
+++ b/src/samples/Blazing.SubpathHosting.Server/Blazing.SubpathHosting.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>

--- a/src/samples/HybridSamples/HybridSample.Avalonia/HybridSample.Avalonia.csproj
+++ b/src/samples/HybridSamples/HybridSample.Avalonia/HybridSample.Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
     <TrimMode>copyused</TrimMode>

--- a/src/samples/HybridSamples/HybridSample.Avalonia/MainWindow.axaml
+++ b/src/samples/HybridSamples/HybridSample.Avalonia/MainWindow.axaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="clr-namespace:HybridSample.Avalonia.ViewModels"
+    xmlns:local="clr-namespace:HybridSample.Avalonia"
     Height="800" Width="1000"  d:DesignHeight="500" d:DesignWidth="800"
     x:DataType="vm:MainWindowViewModel"
     Title="Avalonia MVVM Blazor Hybrid Sample Application" Background="DarkGray"
@@ -38,9 +39,9 @@
             </ItemsControl.ItemTemplate>
         </ItemsControl>
 
-        <blazor:BlazorWebView Grid.Column="1" Grid.Row="0"
+        <blazor:BlazorWebView x:Name="BlazorWebView"
+                              Grid.Column="1" Grid.Row="0"
                               HostPage="index.html"
-                              RootComponents="{DynamicResource rootComponents}"
                               Services="{DynamicResource services}" />
 
         <Label Grid.Row="1"  Grid.ColumnSpan="2"

--- a/src/samples/HybridSamples/HybridSample.Avalonia/MainWindow.axaml.cs
+++ b/src/samples/HybridSamples/HybridSample.Avalonia/MainWindow.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
+using Microsoft.AspNetCore.Components.WebView;
 using Microsoft.AspNetCore.Components.WebView.WindowsForms;
+using System;
 
 namespace HybridSample.Avalonia;
 
@@ -15,11 +17,16 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         IServiceProvider? services = (Application.Current as App)?.Services;
-        RootComponentsCollection rootComponents = new() { new("#app", typeof(HybridApp), null) };
 
         Resources.Add("services", services);
-        Resources.Add("rootComponents", rootComponents);
 
         InitializeComponent();
+
+        // Configure root components after the BlazorWebView is created
+        var blazorWebView = this.Find<Baksteen.Avalonia.Blazor.BlazorWebView>("BlazorWebView");
+        if (blazorWebView != null)
+        {
+            blazorWebView.RootComponents.Add(new RootComponent("#app", typeof(HybridApp), null));
+        }
     }
 }

--- a/src/samples/HybridSamples/HybridSample.Wpf/HybridSample.Wpf.csproj
+++ b/src/samples/HybridSamples/HybridSample.Wpf/HybridSample.Wpf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
 	  <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/samples/HybridSamples/core/HybridSample.Blazor.Core/HybridSample.Blazor.Core.csproj
+++ b/src/samples/HybridSamples/core/HybridSample.Blazor.Core/HybridSample.Blazor.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 	  <Version>1.4.0</Version>

--- a/src/samples/HybridSamples/core/HybridSample.Core/HybridSample.Core.csproj
+++ b/src/samples/HybridSamples/core/HybridSample.Core/HybridSample.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
+	  <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 	  <Nullable>enable</Nullable>
 	  <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>4e66f7b4-01a8-4f00-8733-4ae6a08c741f</UserSecretsId>

--- a/src/samples/HybridSamples/libs/Baksteen.Avalonia.Blazor/Baksteen.Avalonia.Blazor.csproj
+++ b/src/samples/HybridSamples/libs/Baksteen.Avalonia.Blazor/Baksteen.Avalonia.Blazor.csproj
@@ -3,7 +3,7 @@
   <Title>Baksteen.Avalonia.Blazor</Title>
     <Summary>Avalonia BlazorWebView component</Summary>
     <Description>Avalonia BlazorWebView component</Description>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Baksteen.Avalonia.Blazor</RootNamespace>
     <Nullable>enable</Nullable>
@@ -11,7 +11,7 @@
 	  <PackageId>Baksteen.Avalonia.Blazor</PackageId>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
 	  <PackageTags>avalonia;blazor;blazorhybrid;hybrid;webview;webview2</PackageTags>
-	  <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+	  <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	  <Authors>jpmikkers</Authors>
 	  <Description>BlazorWebView for Avalonia 11 (preview 6).</Description>
 	  <RepositoryType>git</RepositoryType>
@@ -21,7 +21,6 @@
 	  <Copyright>Copyright (c) JPMikkers 2023</Copyright>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
 	  <Version>0.5.0-preview</Version>
-	  <PackageIcon>icon.png</PackageIcon>
 	  <IncludeSymbols>False</IncludeSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -31,6 +30,7 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.ReactiveUI" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView" />
   </ItemGroup>
   <ItemGroup>
     <None Update="icon.png">

--- a/src/samples/HybridSamples/libs/Baksteen.Avalonia.Blazor/BlazorWebView.cs
+++ b/src/samples/HybridSamples/libs/Baksteen.Avalonia.Blazor/BlazorWebView.cs
@@ -4,7 +4,6 @@ using Avalonia.Controls.Platform;
 using Avalonia.Platform;
 using DynamicData;
 using Microsoft.AspNetCore.Components.WebView.WindowsForms;
-using System;
 using Avalonia.Interactivity;
 
 namespace Baksteen.Avalonia.Blazor;

--- a/src/samples/HybridSamples/libs/Blazor.Common/Blazing.Common.csproj
+++ b/src/samples/HybridSamples/libs/Blazor.Common/Blazing.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 	  <Version>1.4.0</Version>

--- a/src/samples/HybridSamples/libs/Blazor.Lists/Blazing.Lists.csproj
+++ b/src/samples/HybridSamples/libs/Blazor.Lists/Blazing.Lists.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 	  <Version>1.4.0</Version>

--- a/src/samples/HybridSamples/libs/Blazor.Tabs/Blazing.Tabs.csproj
+++ b/src/samples/HybridSamples/libs/Blazor.Tabs/Blazing.Tabs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
feat: net10.0 support; all sample projects now support net8.0, net9.0, net10.0 (maui excludes net8.0); Tests now multitarget; added Running_Different_NET_Versions.md document to help with samples targeting framework versions.